### PR TITLE
installed poltergeist and phantomjs gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,8 @@ group :development, :test do
   gem 'database_cleaner'
   gem 'launchy'
   gem 'pry'
+	gem 'poltergeist'
+  gem 'phantomjs', require: 'phantomjs/poltergeist'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       railties (>= 3.0)
       sass-rails (>= 3.2)
     chunky_png (1.3.5)
+    cliver (0.3.2)
     coderay (1.1.1)
     coffee-rails (4.1.1)
       coffee-script (>= 2.2.0)
@@ -160,6 +161,11 @@ GEM
       mini_portile2 (~> 2.0.0.rc2)
     orm_adapter (0.5.0)
     pg (0.18.4)
+    phantomjs (2.1.1.0)
+    poltergeist (1.12.0)
+      capybara (~> 2.1)
+      cliver (~> 0.3.1)
+      websocket-driver (>= 0.2.0)
     pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -255,6 +261,9 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    websocket-driver (0.6.4)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.2)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -273,6 +282,8 @@ DEPENDENCIES
   launchy
   mailboxer
   pg (~> 0.15)
+  phantomjs
+  poltergeist
   pry
   rails (= 4.2.5)
   rails_12factor


### PR DESCRIPTION
Pivotal Tracker story: https://www.pivotaltracker.com/story/show/136107639

Changes proposed in this pull request:

Install poltergeist and phantomjs gems for Capybara testing of JS in acceptance tests.

What I have learned working on this feature:

These gems help us test functionality of our javascripts created by for instance other gems like Chosen.

Ready for review!